### PR TITLE
Rephrase /prayer/people consent copy for self-signup

### DIFF
--- a/python_anywhere_website/prayer/templates/prayer/prayer-people.html
+++ b/python_anywhere_website/prayer/templates/prayer/prayer-people.html
@@ -35,6 +35,12 @@
     {% endif %}
 
     <h3>Add New Person</h3>
+    <p>
+        By adding yourself, you agree to our
+        <a href="{% url 'core_app:privacy_policy' %}">Privacy Policy</a>
+        and
+        <a href="{% url 'core_app:terms_of_service' %}">Terms and Conditions</a>.
+    </p>
     <form action="#" method="POST">
         {% csrf_token %}
         {{ new_person_form | crispy }}

--- a/python_anywhere_website/prayer/tests.py
+++ b/python_anywhere_website/prayer/tests.py
@@ -3,6 +3,7 @@ from http import HTTPStatus
 from django.contrib.auth.models import User
 from django.test import Client
 from django.test import TestCase
+from django.urls import reverse
 
 
 # Create your tests here.
@@ -265,6 +266,25 @@ class TestAccessControl(TestCase):
                     HTTPStatus.OK,
                     f"{url} should be accessible to authenticated users",
                 )
+
+
+    def test_people_page_shows_privacy_and_terms_links(self):
+        """People page should show Privacy Policy and Terms links near add person form."""
+        client = Client()
+        client.force_login(self.regular_user)
+
+        response = client.get("/prayer/people")
+
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        self.assertContains(
+            response, f'href="{reverse("core_app:privacy_policy")}"'
+        )
+        self.assertContains(
+            response, f'href="{reverse("core_app:terms_of_service")}"'
+        )
+        self.assertContains(response, "Privacy Policy")
+        self.assertContains(response, "Terms and Conditions")
+        self.assertContains(response, "By adding yourself, you agree to our")
 
     def test_message_detail_requires_authentication(self):
         """


### PR DESCRIPTION
### Motivation
- Clarify the consent copy on the `/prayer/people` page so it explicitly states the user is adding themselves rather than implying a third party is being added.

### Description
- Updated the consent sentence in `python_anywhere_website/prayer/templates/prayer/prayer-people.html` to "By adding yourself, you agree to our ..." and preserved the Privacy Policy and Terms links.
- Extended `python_anywhere_website/prayer/tests.py` to import `reverse` and assert the new phrasing is rendered alongside the existing link and label checks.

### Testing
- Ran `python python_anywhere_website/manage.py test` which executed 56 tests with 6 skipped and completed successfully (`OK (skipped=6)`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6993d82a082083238a5f91b8d784677e)