### PR TITLE
Handle Twilio webhook signature validation when proxy rewrites scheme

### DIFF
--- a/python_anywhere_website/prayer/tests_inbound_sms.py
+++ b/python_anywhere_website/prayer/tests_inbound_sms.py
@@ -80,6 +80,33 @@ class TwilioWebhookTests(TestCase):
         self.assertEqual(saved.body, "Need prayer")
 
     @override_settings(TWILIO_AUTH_TOKEN="test-token")
+    @patch("prayer.views.RequestValidator.validate")
+    def test_webhook_accepts_valid_signature_when_https_fallback_matches(
+        self, validator_mock
+    ):
+        def validate_side_effect(url, _post_data, _signature):
+            return url.startswith("https://")
+
+        validator_mock.side_effect = validate_side_effect
+
+        response = self.client.post(
+            "/api/webhooks/twilio/sms/",
+            {
+                "MessageSid": "SM201",
+                "From": "+15550001111",
+                "To": "+18005550100",
+                "Body": "Proxy mismatch",
+            },
+            HTTP_HOST="example.com",
+            HTTP_X_TWILIO_SIGNATURE="sig",
+            wsgi_url_scheme="http",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(InboundSmsMessage.objects.count(), 1)
+        self.assertEqual(validator_mock.call_count, 2)
+
+    @override_settings(TWILIO_AUTH_TOKEN="test-token")
     @patch("prayer.views.RequestValidator.validate", return_value=True)
     def test_webhook_returns_400_when_required_fields_missing(self, _validator):
         response = self.client.post(

--- a/python_anywhere_website/prayer/views.py
+++ b/python_anywhere_website/prayer/views.py
@@ -7,6 +7,7 @@ from django.shortcuts import render, redirect
 from django.utils import timezone
 from django.views.decorators.csrf import csrf_exempt
 from twilio.request_validator import RequestValidator
+from urllib.parse import urlsplit, urlunsplit
 
 # from logic.users_groups import is_group
 from prayer.forms import (
@@ -460,7 +461,35 @@ def _is_valid_twilio_signature(request) -> bool:
         return False
 
     validator = RequestValidator(twilio_token)
-    return validator.validate(request.build_absolute_uri(), request.POST, signature)
+
+    candidate_urls = _twilio_signature_candidate_urls(request)
+    for url in candidate_urls:
+        if validator.validate(url, request.POST, signature):
+            return True
+    return False
+
+
+def _twilio_signature_candidate_urls(request):
+    """
+    Return candidate absolute URLs for Twilio signature validation.
+
+    Twilio signs the exact webhook URL (including scheme). Some reverse proxies
+    can forward requests to Django as plain HTTP even when the public URL is
+    HTTPS, so we try both variants.
+    """
+    absolute_url = request.build_absolute_uri()
+    parsed = urlsplit(absolute_url)
+
+    candidates = [absolute_url]
+    if parsed.scheme in {"http", "https"}:
+        alt_scheme = "https" if parsed.scheme == "http" else "http"
+        alt_url = urlunsplit(
+            (alt_scheme, parsed.netloc, parsed.path, parsed.query, parsed.fragment)
+        )
+        candidates.append(alt_url)
+
+    # Remove duplicates while preserving order.
+    return list(dict.fromkeys(candidates))
 
 
 @csrf_exempt


### PR DESCRIPTION
### Motivation
- Twilio signs the full webhook URL (including scheme), but some reverse proxies forward requests to Django over `http` even when the public URL is `https`, causing signature validation to fail.
- Make signature validation resilient to scheme rewrites so inbound SMS webhooks are not rejected by a proxy-induced mismatch.

### Description
- Updated Twilio validation in `prayer/views.py` so `_is_valid_twilio_signature` tests multiple candidate URLs (the original `request.build_absolute_uri()` plus an alternate scheme variant) instead of a single URL. 
- Added helper ` _twilio_signature_candidate_urls(request)` which builds deterministic candidate absolute URLs and deduplicates them while preserving order. 
- Added a regression test `test_webhook_accepts_valid_signature_when_https_fallback_matches` in `prayer/tests_inbound_sms.py` that simulates a proxy scheme mismatch and asserts the webhook succeeds when the HTTPS fallback validates and that both candidates were attempted. 
- Modified files: `python_anywhere_website/prayer/views.py` and `python_anywhere_website/prayer/tests_inbound_sms.py`.

### Testing
- Ran the full Django test suite with `cd python_anywhere_website && python manage.py test`, which executed 56 tests and completed with status `OK` (6 tests skipped).
- The new regression test was executed as part of the suite and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaddaeff588323a8063dddc79ee198)