### PR TITLE
Validate Twilio webhook signatures using forwarded host/proto and candidate URLs

### DIFF
--- a/python_anywhere_website/main_app/settings.py
+++ b/python_anywhere_website/main_app/settings.py
@@ -184,6 +184,9 @@ CRISPY_TEMPLATE_PACK = "bootstrap5"
 # This ensures request.build_absolute_uri() returns https:// URLs so that
 # third-party webhook signature validation (e.g. Twilio) works correctly.
 SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
+# Trust X-Forwarded-Host as well so host reconstruction behind the proxy
+# matches the public host used by providers signing webhook callbacks.
+USE_X_FORWARDED_HOST = True
 
 # Login, Signup redirects
 LOGIN_URL = "login"

--- a/python_anywhere_website/prayer/tests_inbound_sms.py
+++ b/python_anywhere_website/prayer/tests_inbound_sms.py
@@ -80,6 +80,65 @@ class TwilioWebhookTests(TestCase):
         self.assertEqual(saved.body, "Need prayer")
 
     @override_settings(TWILIO_AUTH_TOKEN="test-token")
+    @patch("prayer.views.RequestValidator.validate")
+    def test_webhook_accepts_valid_signature_when_https_fallback_matches(
+        self, validator_mock
+    ):
+        def validate_side_effect(url, _post_data, _signature):
+            return url.startswith("https://")
+
+        validator_mock.side_effect = validate_side_effect
+
+        response = self.client.post(
+            "/api/webhooks/twilio/sms/",
+            {
+                "MessageSid": "SM201",
+                "From": "+15550001111",
+                "To": "+18005550100",
+                "Body": "Proxy mismatch",
+            },
+            HTTP_HOST="example.com",
+            HTTP_X_TWILIO_SIGNATURE="sig",
+            wsgi_url_scheme="http",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(InboundSmsMessage.objects.count(), 1)
+        self.assertEqual(validator_mock.call_count, 2)
+
+    @override_settings(TWILIO_AUTH_TOKEN="test-token")
+    @patch("prayer.views.RequestValidator.validate")
+    def test_webhook_accepts_valid_signature_with_forwarded_host_and_proto(
+        self, validator_mock
+    ):
+        expected_url = "https://www.jacob-mcgowin.us/api/webhooks/twilio/sms/"
+
+        def validate_side_effect(url, _post_data, _signature):
+            return url == expected_url
+
+        validator_mock.side_effect = validate_side_effect
+
+        response = self.client.post(
+            "/api/webhooks/twilio/sms/",
+            {
+                "MessageSid": "SM202",
+                "From": "+15550001111",
+                "To": "+18005550100",
+                "Body": "Forwarded host/proto",
+            },
+            HTTP_HOST="username.pythonanywhere.com",
+            HTTP_X_FORWARDED_HOST="www.jacob-mcgowin.us",
+            HTTP_X_FORWARDED_PROTO="http,https",
+            HTTP_X_TWILIO_SIGNATURE="sig",
+            wsgi_url_scheme="http",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(InboundSmsMessage.objects.count(), 1)
+        validated_urls = [call.args[0] for call in validator_mock.call_args_list]
+        self.assertIn(expected_url, validated_urls)
+
+    @override_settings(TWILIO_AUTH_TOKEN="test-token")
     @patch("prayer.views.RequestValidator.validate", return_value=True)
     def test_webhook_returns_400_when_required_fields_missing(self, _validator):
         response = self.client.post(

--- a/python_anywhere_website/prayer/views.py
+++ b/python_anywhere_website/prayer/views.py
@@ -7,6 +7,7 @@ from django.shortcuts import render, redirect
 from django.utils import timezone
 from django.views.decorators.csrf import csrf_exempt
 from twilio.request_validator import RequestValidator
+from urllib.parse import urlsplit, urlunsplit
 
 # from logic.users_groups import is_group
 from prayer.forms import (
@@ -460,7 +461,56 @@ def _is_valid_twilio_signature(request) -> bool:
         return False
 
     validator = RequestValidator(twilio_token)
-    return validator.validate(request.build_absolute_uri(), request.POST, signature)
+
+    candidate_urls = _twilio_signature_candidate_urls(request)
+    for url in candidate_urls:
+        if validator.validate(url, request.POST, signature):
+            return True
+    return False
+
+
+def _twilio_signature_candidate_urls(request):
+    """
+    Return candidate absolute URLs for Twilio signature validation.
+
+    Twilio signs the exact webhook URL (including scheme). Some reverse proxies
+    can forward requests to Django as plain HTTP even when the public URL is
+    HTTPS, so we try both variants.
+    """
+    absolute_url = request.build_absolute_uri()
+    parsed = urlsplit(absolute_url)
+    path_with_query = urlunsplit(("", "", parsed.path, parsed.query, ""))
+
+    # Build host and scheme options from both direct request metadata and
+    # reverse-proxy forwarding headers.
+    host_candidates = [parsed.netloc]
+    for header_name in ("HTTP_X_FORWARDED_HOST", "HTTP_HOST"):
+        header_value = request.META.get(header_name, "")
+        if header_value:
+            first_host = header_value.split(",")[0].strip()
+            if first_host:
+                host_candidates.append(first_host)
+
+    scheme_candidates = [parsed.scheme]
+    forwarded_proto = request.META.get("HTTP_X_FORWARDED_PROTO", "")
+    if forwarded_proto:
+        for proto in forwarded_proto.split(","):
+            normalized_proto = proto.strip().lower()
+            if normalized_proto in {"http", "https"}:
+                scheme_candidates.append(normalized_proto)
+
+    if "http" not in scheme_candidates:
+        scheme_candidates.append("http")
+    if "https" not in scheme_candidates:
+        scheme_candidates.append("https")
+
+    candidates = [absolute_url]
+    for scheme in scheme_candidates:
+        for host in host_candidates:
+            candidates.append(f"{scheme}://{host}{path_with_query}")
+
+    # Remove duplicates while preserving order.
+    return list(dict.fromkeys(candidates))
 
 
 @csrf_exempt


### PR DESCRIPTION
### Motivation
- Ensure Twilio webhook signature validation succeeds when Django is behind a reverse proxy that rewrites scheme or host, so inbound SMS webhooks are accepted and processed. 

### Description
- Add `USE_X_FORWARDED_HOST = True` to settings to allow host reconstruction from `X-Forwarded-Host`.
- Enhance Twilio validation in `prayer.views` by trying multiple candidate absolute URLs (including variations derived from `HTTP_X_FORWARDED_HOST` and `HTTP_X_FORWARDED_PROTO`) before rejecting the signature, and factor URL construction into `_twilio_signature_candidate_urls` using `urlsplit`/`urlunsplit`.
- Update `twilio_sms_webhook` to use the new multi-candidate validation flow without changing existing request handling.
- Add unit tests in `prayer/tests_inbound_sms.py` to cover HTTPS fallback and forwarded host/proto scenarios used during signature validation.

### Testing
- Ran the Django tests for the inbound SMS webhook (`python manage.py test prayer.tests_inbound_sms.TwilioWebhookTests`) which include the new cases, and they passed.
- Existing Twilio webhook-related tests were executed and remained green after the changes.
- No other automated tests failed during the rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaddaeff588323a8063dddc79ee198)