### PR TITLE
Improve Twilio webhook signature validation to handle reverse proxies and env token fallback

### DIFF
--- a/python_anywhere_website/main_app/settings.py
+++ b/python_anywhere_website/main_app/settings.py
@@ -184,6 +184,9 @@ CRISPY_TEMPLATE_PACK = "bootstrap5"
 # This ensures request.build_absolute_uri() returns https:// URLs so that
 # third-party webhook signature validation (e.g. Twilio) works correctly.
 SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
+# Trust X-Forwarded-Host as well so host reconstruction behind the proxy
+# matches the public host used by providers signing webhook callbacks.
+USE_X_FORWARDED_HOST = True
 
 # Login, Signup redirects
 LOGIN_URL = "login"

--- a/python_anywhere_website/prayer/tests_inbound_sms.py
+++ b/python_anywhere_website/prayer/tests_inbound_sms.py
@@ -1,4 +1,4 @@
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 from django.contrib.auth.models import User
 from django.test import TestCase, override_settings
@@ -80,6 +80,65 @@ class TwilioWebhookTests(TestCase):
         self.assertEqual(saved.body, "Need prayer")
 
     @override_settings(TWILIO_AUTH_TOKEN="test-token")
+    @patch("prayer.views.RequestValidator.validate")
+    def test_webhook_accepts_valid_signature_when_https_fallback_matches(
+        self, validator_mock
+    ):
+        def validate_side_effect(url, _post_data, _signature):
+            return url.startswith("https://")
+
+        validator_mock.side_effect = validate_side_effect
+
+        response = self.client.post(
+            "/api/webhooks/twilio/sms/",
+            {
+                "MessageSid": "SM201",
+                "From": "+15550001111",
+                "To": "+18005550100",
+                "Body": "Proxy mismatch",
+            },
+            HTTP_HOST="example.com",
+            HTTP_X_TWILIO_SIGNATURE="sig",
+            wsgi_url_scheme="http",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(InboundSmsMessage.objects.count(), 1)
+        self.assertEqual(validator_mock.call_count, 2)
+
+    @override_settings(TWILIO_AUTH_TOKEN="test-token")
+    @patch("prayer.views.RequestValidator.validate")
+    def test_webhook_accepts_valid_signature_with_forwarded_host_and_proto(
+        self, validator_mock
+    ):
+        expected_url = "https://www.jacob-mcgowin.us/api/webhooks/twilio/sms/"
+
+        def validate_side_effect(url, _post_data, _signature):
+            return url == expected_url
+
+        validator_mock.side_effect = validate_side_effect
+
+        response = self.client.post(
+            "/api/webhooks/twilio/sms/",
+            {
+                "MessageSid": "SM202",
+                "From": "+15550001111",
+                "To": "+18005550100",
+                "Body": "Forwarded host/proto",
+            },
+            HTTP_HOST="username.pythonanywhere.com",
+            HTTP_X_FORWARDED_HOST="www.jacob-mcgowin.us",
+            HTTP_X_FORWARDED_PROTO="http,https",
+            HTTP_X_TWILIO_SIGNATURE="sig",
+            wsgi_url_scheme="http",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(InboundSmsMessage.objects.count(), 1)
+        validated_urls = [call.args[0] for call in validator_mock.call_args_list]
+        self.assertIn(expected_url, validated_urls)
+
+    @override_settings(TWILIO_AUTH_TOKEN="test-token")
     @patch("prayer.views.RequestValidator.validate", return_value=True)
     def test_webhook_returns_400_when_required_fields_missing(self, _validator):
         response = self.client.post(
@@ -92,6 +151,29 @@ class TwilioWebhookTests(TestCase):
         )
 
         self.assertEqual(response.status_code, 400)
+
+    @patch.dict("os.environ", {"TWILIO_AUTH_TOKEN": "env-token"}, clear=False)
+    @patch("prayer.views.RequestValidator")
+    def test_webhook_uses_env_twilio_token_when_setting_missing(
+        self, request_validator_cls
+    ):
+        request_validator = Mock()
+        request_validator.validate.return_value = True
+        request_validator_cls.return_value = request_validator
+
+        response = self.client.post(
+            "/api/webhooks/twilio/sms/",
+            {
+                "MessageSid": "SM203",
+                "From": "+15550001111",
+                "To": "+18005550100",
+                "Body": "Env token fallback",
+            },
+            HTTP_X_TWILIO_SIGNATURE="sig",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        request_validator_cls.assert_called_once_with("env-token")
 
 
 class InboundMessagesViewTests(TestCase):

--- a/python_anywhere_website/prayer/views.py
+++ b/python_anywhere_website/prayer/views.py
@@ -1,3 +1,6 @@
+import logging
+import os
+
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.admin.views.decorators import staff_member_required
@@ -7,6 +10,7 @@ from django.shortcuts import render, redirect
 from django.utils import timezone
 from django.views.decorators.csrf import csrf_exempt
 from twilio.request_validator import RequestValidator
+from urllib.parse import urlsplit, urlunsplit
 
 # from logic.users_groups import is_group
 from prayer.forms import (
@@ -34,6 +38,9 @@ def is_group(user, group):
         return True
     else:
         return False
+
+
+logger = logging.getLogger(__name__)
 
 
 # Create your views here.
@@ -453,14 +460,89 @@ def public_signup(request) -> render:
 def _is_valid_twilio_signature(request) -> bool:
     signature = request.META.get("HTTP_X_TWILIO_SIGNATURE")
     if not signature:
+        logger.warning("Twilio webhook rejected: missing X-Twilio-Signature header")
         return False
 
-    twilio_token = getattr(settings, "TWILIO_AUTH_TOKEN", "")
+    twilio_token = _get_twilio_auth_token()
     if not twilio_token:
+        logger.error("Twilio webhook rejected: TWILIO_AUTH_TOKEN is not configured")
         return False
 
     validator = RequestValidator(twilio_token)
-    return validator.validate(request.build_absolute_uri(), request.POST, signature)
+
+    candidate_urls = _twilio_signature_candidate_urls(request)
+    for url in candidate_urls:
+        if validator.validate(url, request.POST, signature):
+            return True
+    logger.warning(
+        "Twilio webhook rejected: signature validation failed for all %s candidate URLs",
+        len(candidate_urls),
+    )
+    return False
+
+
+def _get_twilio_auth_token() -> str:
+    """
+    Read Twilio auth token from supported config locations.
+    """
+    settings_token = str(getattr(settings, "TWILIO_AUTH_TOKEN", "")).strip()
+    if settings_token:
+        return settings_token
+
+    env_token = os.environ.get("TWILIO_AUTH_TOKEN", "").strip()
+    if env_token:
+        return env_token
+
+    # Legacy fallback used elsewhere in this project for outbound SMS.
+    try:
+        from logic.Messaging.sms import TWILIO_AUTH_TOKEN as legacy_token
+    except Exception:
+        legacy_token = ""
+    return str(legacy_token).strip()
+
+
+def _twilio_signature_candidate_urls(request):
+    """
+    Return candidate absolute URLs for Twilio signature validation.
+
+    Twilio signs the exact webhook URL (including scheme). Some reverse proxies
+    can forward requests to Django as plain HTTP even when the public URL is
+    HTTPS, so we try both variants.
+    """
+    absolute_url = request.build_absolute_uri()
+    parsed = urlsplit(absolute_url)
+    path_with_query = urlunsplit(("", "", parsed.path, parsed.query, ""))
+
+    # Build host and scheme options from both direct request metadata and
+    # reverse-proxy forwarding headers.
+    host_candidates = [parsed.netloc]
+    for header_name in ("HTTP_X_FORWARDED_HOST", "HTTP_HOST"):
+        header_value = request.META.get(header_name, "")
+        if header_value:
+            first_host = header_value.split(",")[0].strip()
+            if first_host:
+                host_candidates.append(first_host)
+
+    scheme_candidates = [parsed.scheme]
+    forwarded_proto = request.META.get("HTTP_X_FORWARDED_PROTO", "")
+    if forwarded_proto:
+        for proto in forwarded_proto.split(","):
+            normalized_proto = proto.strip().lower()
+            if normalized_proto in {"http", "https"}:
+                scheme_candidates.append(normalized_proto)
+
+    if "http" not in scheme_candidates:
+        scheme_candidates.append("http")
+    if "https" not in scheme_candidates:
+        scheme_candidates.append("https")
+
+    candidates = [absolute_url]
+    for scheme in scheme_candidates:
+        for host in host_candidates:
+            candidates.append(f"{scheme}://{host}{path_with_query}")
+
+    # Remove duplicates while preserving order.
+    return list(dict.fromkeys(candidates))
 
 
 @csrf_exempt


### PR DESCRIPTION
### Motivation

- Ensure Twilio webhook signature validation works when Django is behind a reverse proxy that changes host or scheme, and provide better error logging for signature failures. 
- Allow the Twilio auth token to be read from environment or legacy locations when the settings variable is not present.

### Description

- Add `USE_X_FORWARDED_HOST = True` to settings so host reconstruction can prefer `X-Forwarded-Host` when present. 
- In `prayer.views`, add logging and a multi-source Twilio token lookup via `_get_twilio_auth_token()` that checks `settings`, environment `TWILIO_AUTH_TOKEN`, and a legacy import fallback. 
- Replace single-call signature validation with `_twilio_signature_candidate_urls()` and loop over candidate absolute URLs (including combinations derived from `HTTP_X_FORWARDED_HOST` and `HTTP_X_FORWARDED_PROTO`) to validate the Twilio signature, with warnings and errors logged on failure. 
- Update imports to include `os` and `urllib.parse`, and add `logger` for diagnostic messages. 
- Expand `prayer/tests_inbound_sms.py` to use `Mock`, add tests for HTTPS fallback, forwarded host/proto handling, and env token fallback, and assert expected validation behavior and `RequestValidator` usage.

### Testing

- Added unit tests in `prayer/tests_inbound_sms.py` covering HTTPS fallback, forwarded host/proto candidate URL validation, and environment token fallback. 
- Ran `python manage.py test prayer.tests_inbound_sms` and the new/updated tests passed. 
- Existing `prayer` inbound message tests were run as part of the same test target and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaddaeff588323a8063dddc79ee198)