### PR TITLE
Add robots.txt endpoint and tests; expose at site root

### DIFF
--- a/python_anywhere_website/core_app/tests.py
+++ b/python_anywhere_website/core_app/tests.py
@@ -226,3 +226,23 @@ class CompliancePolicyTests(TestCase):
             resp, "Carriers are not liable for delayed or undelivered messages"
         )
         self.assertContains(resp, "Message frequency varies")
+
+
+class RobotsTxtTests(TestCase):
+    """Tests for robots.txt endpoint."""
+
+    def test_robots_txt_available_at_site_root(self):
+        resp = self.client.get("/robots.txt")
+        self.assertEqual(resp.status_code, 200)
+
+    def test_robots_txt_content_and_content_type(self):
+        resp = self.client.get("/robots.txt")
+        self.assertEqual(resp["Content-Type"], "text/plain")
+        self.assertEqual(
+            resp.content.decode("utf-8"),
+            "User-agent: *\nDisallow: /prayer/\n",
+        )
+
+    def test_robots_txt_disallows_prayer_app(self):
+        resp = self.client.get("/robots.txt")
+        self.assertContains(resp, "Disallow: /prayer/")

--- a/python_anywhere_website/main_app/urls.py
+++ b/python_anywhere_website/main_app/urls.py
@@ -20,13 +20,14 @@ from django.conf import settings
 from django.conf.urls.static import static
 
 # from django.shortcuts import redirect
-from .views import redirect_home
+from .views import redirect_home, robots_txt
 from bible.urls import api_urlpatterns as bible_api_urls
 from prayer import views as prayer_views
 
 urlpatterns = [
     path("admin/", admin.site.urls),
     path("", redirect_home),
+    path("robots.txt", robots_txt, name="robots_txt"),
     # core_app is available under /core_app/ (auth and app URLs)
     # Removed duplicate include at /home/ to avoid namespace collision
     path("fs2020/", include("fs2020.urls", namespace="fs2020")),

--- a/python_anywhere_website/main_app/views.py
+++ b/python_anywhere_website/main_app/views.py
@@ -1,6 +1,4 @@
-from django.shortcuts import render
-
-# from .models import Aircraft, Flight
+from django.http import HttpResponse
 from django.shortcuts import redirect
 
 
@@ -11,3 +9,13 @@ def redirect_home(request):
     """
     response = redirect("core_app:index")
     return response
+
+
+def robots_txt(request):
+    """
+    Serve robots.txt for crawlers.
+    """
+    return HttpResponse(
+        "User-agent: *\nDisallow: /prayer/\n",
+        content_type="text/plain",
+    )


### PR DESCRIPTION
### Motivation
- Provide a simple `robots.txt` at the site root to instruct crawlers to avoid the prayer app (`/prayer/`).

### Description
- Add a `robots_txt` view in `main_app/views.py` that returns a plain text `robots.txt` with the content `User-agent: *\nDisallow: /prayer/\n` using `HttpResponse` and `content_type="text/plain"`.
- Expose the endpoint at site root by adding `path("robots.txt", robots_txt, name="robots_txt")` to `main_app/urls.py` and import the view.
- Add `RobotsTxtTests` to `core_app/tests.py` with tests that verify the endpoint is available at `/robots.txt`, has `Content-Type: text/plain`, contains the expected content string, and specifically disallows `/prayer/`.

### Testing
- Ran the Django test suite via `./manage.py test` and the new `RobotsTxtTests` passed.  All tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eae73518fc8323b11dd523644cc4bd)