### PR TITLE
Add blog link to navbar

### DIFF
--- a/python_anywhere_website/core_app/tests.py
+++ b/python_anywhere_website/core_app/tests.py
@@ -110,6 +110,15 @@ class SignUpTests(TestCase):
 class NavbarAccountsTests(TestCase):
     """Tests for the accounts dropdown in the navbar."""
 
+    def test_navbar_shows_blog_link(self):
+        """Test that the navbar links to the external blog."""
+        resp = self.client.get("/", follow=True)
+        self.assertContains(
+            resp,
+            '<a class="nav-link" href="https://blog.jacob-mcgowin.us">Blog</a>',
+            html=True,
+        )
+
     def test_navbar_shows_login_and_signup_when_anonymous(self):
         """Test that unauthenticated users see Login and Signup in navbar."""
         resp = self.client.get("/")

--- a/python_anywhere_website/templates/shared/navbar.html
+++ b/python_anywhere_website/templates/shared/navbar.html
@@ -11,6 +11,7 @@
     <div class="collapse navbar-collapse" id="mainNav">
       <ul class="navbar-nav ms-auto align-items-lg-center">
         <li class="nav-item"><a class="nav-link" href="/">Home</a></li>
+        <li class="nav-item"><a class="nav-link" href="https://blog.jacob-mcgowin.us">Blog</a></li>
         <li class="nav-item dropdown">
           <a class="nav-link dropdown-toggle" href="/fs2020/" id="fs2020Dropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">FS2020</a>
           <ul class="dropdown-menu dropdown-menu-dark" aria-labelledby="fs2020Dropdown">


### PR DESCRIPTION
## Summary

- Add a Blog item to the shared site navbar.
- Link it to `https://blog.jacob-mcgowin.us`.
- Add a regression test confirming the external link renders.

## Why

Visitors need a direct way to reach the blog from the main website navigation.

## Impact

The Blog link appears beside Home anywhere the shared navbar is used. Existing navigation and account behavior are unchanged.

## Validation

- `python manage.py test core_app.tests.NavbarAccountsTests` (5 tests passed)
- `git diff --check`