### PR TITLE
Add blog signup form to homepage

### DIFF
--- a/python_anywhere_website/core_app/tests.py
+++ b/python_anywhere_website/core_app/tests.py
@@ -18,6 +18,19 @@ class SanityTests(TestCase):
         self.assertIn(resp.status_code, (200, 302))
 
 
+class HomePageTests(TestCase):
+    def test_homepage_shows_blog_signup_form(self):
+        resp = self.client.get("/", follow=True)
+
+        self.assertContains(resp, "From the Blog")
+        self.assertContains(
+            resp,
+            "https://cdn.jsdelivr.net/ghost/signup-form@~0.3/umd/signup-form.min.js",
+        )
+        self.assertContains(resp, 'data-site="https://blog.jacob-mcgowin.us/"')
+        self.assertNotContains(resp, "Lorem ipsum")
+
+
 class AuthFlowTests(TestCase):
     def setUp(self):
         self.username = "testuser"

--- a/python_anywhere_website/templates/core_app/index.html
+++ b/python_anywhere_website/templates/core_app/index.html
@@ -18,10 +18,10 @@
 
             <div class="card home-card col-lg m-2 shadow-sm">
                 <div class="card-body">
-                  <h5 class="card-title">Meet Jacob!</h5>
-                  <h6 class="card-subtitle mb-2 text-muted">Aircraft and Software Professional</h6>
-                  <p class="card-text">Lorem ipsum dolor sit amet consectetur adipisicing elit. Aliquid atque vero aliquam ipsum natus praesentium fuga sed obcaecati repellendus nulla officia accusamus, totam quaerat sint labore sit vel aperiam quisquam?</p>
-                  <a href="{% url 'resume:index' %}" class="card-link btn btn-primary">More about Jacob</a>
+                  <h5 class="card-title">From the Blog</h5>
+                  <h6 class="card-subtitle mb-2 text-muted">Aviation, software, and life in between</h6>
+                  <p class="card-text">Welcome! I write about the things I fly, build, and learn along the way. Subscribe to get new posts delivered straight to your inbox.</p>
+                  <div style="min-height: 58px;max-width: 440px;margin: 0 auto;width: 100%"><script src="https://cdn.jsdelivr.net/ghost/signup-form@~0.3/umd/signup-form.min.js" data-button-color="#FF1A75" data-button-text-color="#FFFFFF" data-site="https://blog.jacob-mcgowin.us/" data-locale="en" async></script></div>
                 </div>
             </div>
 
@@ -36,17 +36,6 @@
                         </div>
                         {% endcomment %}
 
-            <div class="card home-card col-lg m-2 shadow-sm visually-hidden">
-                <div class="card-body">
-                  <h5 class="card-title">Card title</h5>
-                  <h6 class="card-subtitle mb-2 text-muted">Card subtitle</h6>
-                  <p class="card-text">Lorem ipsum dolor sit amet, consectetur adipisicing elit. Dolorum, animi natus necessitatibus dolores architecto ducimus quis culpa tenetur iure sit pariatur sapiente itaque? Maiores obcaecati repellendus velit! Quo, deserunt autem?</p>
-                  <a href="#" class="card-link btn btn-primary disabled">Card link</a>
-                </div>
-            </div>
-
-
-            
         </div>
     </div>
 {% endblock %}


### PR DESCRIPTION
## Summary

- Replace the homepage lorem ipsum card with a short introduction to Jacob's blog.
- Embed the Ghost newsletter signup form for `blog.jacob-mcgowin.us`.
- Remove the unused hidden placeholder card and its remaining lorem ipsum.
- Add a regression test for the signup embed and homepage copy.

## Why

The homepage should introduce the blog and give visitors a direct way to subscribe instead of displaying placeholder content.

## Impact

Visitors now see a concise blog introduction and can subscribe without leaving the homepage.

## Validation

- `python manage.py test core_app.tests.HomePageTests core_app.tests.NavbarAccountsTests` — 6 passed.
- `python manage.py test core_app` — 24 passed, 1 unrelated existing failure: `CompliancePolicyTests.test_terms_of_service_page_available` expects “Text STOP,” which is absent from the current Terms of Service page.
- `git diff --check` — passed.